### PR TITLE
Fix case-sensitive email matching in waiver processing

### DIFF
--- a/WaiverCheck.py
+++ b/WaiverCheck.py
@@ -106,7 +106,7 @@ class ChildScript(Script):
 							if WA_ID:
 								contact = self.WA_API.GetContactById(WA_ID)
 							else:
-								contact = self.WA_API.GetContactByEmail(waiver.email)[0]
+								contact = self.WA_API.GetContactByEmail(waiver.email.lower())[0]
 								WA_ID = contact['Id']
 							break
 							#print(contact)


### PR DESCRIPTION
Convert waiver email to lowercase before WildApricot lookup to prevent failed matches due to capitalization differences.

- Changed: waiver.email → waiver.email.lower() in GetContactByEmail call
- Fixes: Waivers not matching existing contacts when email case differs

Resolves #20 
